### PR TITLE
Add role and permission fields

### DIFF
--- a/group-manage-service/src/main/java/org/example/groupmanageservice/modules/Participant.java
+++ b/group-manage-service/src/main/java/org/example/groupmanageservice/modules/Participant.java
@@ -26,6 +26,11 @@ public class Participant implements Serializable {
     private ParticipantId id;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "permission")
     private Permission permission;
 
     // Remove any redundant field like "private String roomId;"—the id already contains roomId.
@@ -36,7 +41,11 @@ public class Participant implements Serializable {
     @JsonBackReference
     private Room room;
 
-    public enum Permission {
+    public enum Role {
         HOSTER, PARTICIPANT
+    }
+
+    public enum Permission {
+        READ, WRITE, READ_WRITE
     }
 }

--- a/group-manage-service/src/main/java/org/example/groupmanageservice/service/RoomService.java
+++ b/group-manage-service/src/main/java/org/example/groupmanageservice/service/RoomService.java
@@ -54,7 +54,8 @@ public class RoomService {
         // Create host Participant and add to room's participant list
         Participant host = new Participant();
         host.setId(new ParticipantId(hosterUserId, roomId));
-        host.setPermission(Participant.Permission.HOSTER);
+        host.setRole(Participant.Role.HOSTER);
+        host.setPermission(Participant.Permission.READ_WRITE);
         host.setRoom(room);
         ArrayList<Participant> participants = new ArrayList<>();
         participants.add(host);
@@ -149,7 +150,8 @@ public class RoomService {
         }
         Participant newParticipant = new Participant();
         newParticipant.setId(new ParticipantId(userId, roomId));
-        newParticipant.setPermission(Participant.Permission.PARTICIPANT);
+        newParticipant.setRole(Participant.Role.PARTICIPANT);
+        newParticipant.setPermission(Participant.Permission.READ);
         newParticipant.setRoom(room);
         participantService.updateParticipant(newParticipant);
         room.getParticipants().add(newParticipant);
@@ -176,10 +178,11 @@ public class RoomService {
         Participant participant = participantOpt.get();
         room.getParticipants().remove(participant);
         participantService.deleteParticipant(roomId, userId);
-        if (participant.getPermission() == Participant.Permission.HOSTER) {
+        if (participant.getRole() == Participant.Role.HOSTER) {
             if (!room.getParticipants().isEmpty()) {
                 Participant newHost = room.getParticipants().get(0);
-                newHost.setPermission(Participant.Permission.HOSTER);
+                newHost.setRole(Participant.Role.HOSTER);
+                newHost.setPermission(Participant.Permission.READ_WRITE);
                 room.setHosterUserId(newHost.getId().getUserId());
                 participantService.updateParticipant(newHost);
                 publishEvent(EventType.HOST_CHANGE, roomId, newHost.getId().getUserId());

--- a/group-manage-service/src/test/resources/test-data.sql
+++ b/group-manage-service/src/test/resources/test-data.sql
@@ -11,15 +11,15 @@ INSERT INTO rooms (room_id, hoster_user_id, join_password, status, created_at, u
 VALUES ('room-3', 'host3', '333333', 'CLOSED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Insert dummy participants for room-1 (one per statement)
-INSERT INTO participants (user_id, room_id, permission)
-VALUES ('host1', 'room-1', 'HOSTER');
-INSERT INTO participants (user_id, room_id, permission)
-VALUES ('userA', 'room-1', 'PARTICIPANT');
-INSERT INTO participants (user_id, room_id, permission)
-VALUES ('userB', 'room-1', 'PARTICIPANT');
+INSERT INTO participants (user_id, room_id, role, permission)
+VALUES ('host1', 'room-1', 'HOSTER', 'READ_WRITE');
+INSERT INTO participants (user_id, room_id, role, permission)
+VALUES ('userA', 'room-1', 'PARTICIPANT', 'READ');
+INSERT INTO participants (user_id, room_id, role, permission)
+VALUES ('userB', 'room-1', 'PARTICIPANT', 'READ');
 
 -- Insert dummy participants for room-2
-INSERT INTO participants (user_id, room_id, permission)
-VALUES ('host2', 'room-2', 'HOSTER');
-INSERT INTO participants (user_id, room_id, permission)
-VALUES ('userC', 'room-2', 'PARTICIPANT');
+INSERT INTO participants (user_id, room_id, role, permission)
+VALUES ('host2', 'room-2', 'HOSTER', 'READ_WRITE');
+INSERT INTO participants (user_id, room_id, role, permission)
+VALUES ('userC', 'room-2', 'PARTICIPANT', 'READ');


### PR DESCRIPTION
## Summary
- rename `Permission` enum to `Role`
- introduce new `Permission` enum representing READ/WRITE access
- update `Participant` entity with `role` and new `permission` field
- adjust `RoomService` to use new fields
- update test data

## Testing
- `mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684fc9b1cf648325a9853cc74dff62d9